### PR TITLE
opa test workspace in console

### DIFF
--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/actions/ActionUtils.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/actions/ActionUtils.kt
@@ -1,0 +1,41 @@
+package org.openpolicyagent.ideaplugin.ide.actions
+
+//todo: currently, if a tool window/terminal is selected rather than text editor,
+// these functions don't return the project/document currently displayed
+// possible soln is to make the consoleViews unselectable ?
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import org.openpolicyagent.ideaplugin.lang.psi.isNotRegoFile
+import org.openpolicyagent.ideaplugin.openapiext.virtualFile
+
+    /**
+     * return a nullable Pair congaing the [Project] and the [Document]
+     *
+     * If the project is null or the file is not a Rego file then return null
+     */
+fun getProjectAndDocument(e: AnActionEvent): Pair<Project, Document>? {
+    val project = e.project ?: return null
+    val editor = e.getData(CommonDataKeys.EDITOR_EVEN_IF_INACTIVE) ?: getSelectedEditor(project) ?: return null
+    val document = editor.document
+    val file = document.virtualFile ?: return null
+    if (!file.isInLocalFileSystem || file.isNotRegoFile) return null
+
+
+    return Pair(project, document)
+
+    }
+
+fun getEditor (e: AnActionEvent): Editor? {
+    val project = e.project ?: return null
+    return e.getData(CommonDataKeys.EDITOR_EVEN_IF_INACTIVE) ?: getSelectedEditor(project) ?: return null
+}
+
+fun getSelectedEditor(project: Project): Editor? =
+        FileEditorManager.getInstance(project).selectedTextEditor
+
+

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/actions/CheckAction.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/actions/CheckAction.kt
@@ -1,0 +1,25 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.openpolicyagent.ideaplugin.ide.actions
+
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareAction
+import org.openpolicyagent.ideaplugin.opa.tool.OpaActions
+
+
+class CheckAction : DumbAwareAction() {
+    override fun update(e: AnActionEvent) {
+        super.update(e)
+        e.presentation.isEnabledAndVisible = getProjectAndDocument(e) != null
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val (project, document) = getProjectAndDocument(e) ?: return
+        val editor = getEditor(e) ?: return
+        OpaActions().checkDocument(project, document, editor)
+    }
+}

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/actions/FmtAction.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/actions/FmtAction.kt
@@ -7,15 +7,12 @@ package org.openpolicyagent.ideaplugin.ide.actions
 
 import com.intellij.execution.ExecutionException
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.editor.Document
-import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
-import org.openpolicyagent.ideaplugin.lang.psi.isNotRegoFile
 import org.openpolicyagent.ideaplugin.opa.tool.OpaFmt
 import org.openpolicyagent.ideaplugin.openapiext.*
+
 
 class FmtAction : DumbAwareAction() {
 
@@ -46,25 +43,5 @@ class FmtAction : DumbAwareAction() {
             null
         }
     }
-
-    /**
-     * return a nullable Pair congaing the [Project] and the [Document]
-     *
-     * If the project is null or the file is not a Rego file then return null
-     */
-    private fun getProjectAndDocument(e: AnActionEvent): Pair<Project, Document>? {
-        val project = e.project ?: return null
-        val editor = e.getData(CommonDataKeys.EDITOR_EVEN_IF_INACTIVE) ?: getSelectedEditor(project) ?: return null
-        val document = editor.document
-        val file = document.virtualFile ?: return null
-        if (!file.isInLocalFileSystem || file.isNotRegoFile) return null
-
-
-        return Pair(project, document)
-
-    }
-
-    private fun getSelectedEditor(project: Project): Editor? =
-        FileEditorManager.getInstance(project).selectedTextEditor
 
 }

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/actions/TestAction.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/actions/TestAction.kt
@@ -1,0 +1,19 @@
+package org.openpolicyagent.ideaplugin.ide.actions
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareAction
+import org.openpolicyagent.ideaplugin.opa.tool.OpaActions
+
+
+class TestAction : DumbAwareAction() {
+    override fun update(e: AnActionEvent) {
+        super.update(e)
+        e.presentation.isEnabledAndVisible = getProjectAndDocument(e) != null
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val (project, document) = getProjectAndDocument(e) ?: return
+        val editor = getEditor(e) ?: return
+        OpaActions().testWorkspace(project, document, editor)
+    }
+}

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/actions/TestCoverageAction.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/actions/TestCoverageAction.kt
@@ -1,0 +1,19 @@
+package org.openpolicyagent.ideaplugin.ide.actions
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareAction
+import org.openpolicyagent.ideaplugin.opa.tool.OpaActions
+
+
+class TestCoverageAction : DumbAwareAction() {
+    override fun update(e: AnActionEvent) {
+        super.update(e)
+        e.presentation.isEnabledAndVisible = getProjectAndDocument(e) != null
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val (project, document) = getProjectAndDocument(e) ?: return
+        val editor = getEditor(e) ?: return
+        OpaActions().testWorkspaceCoverage(project, document, editor)
+    }
+}

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/extensions/OPAActionToolWindow.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/extensions/OPAActionToolWindow.kt
@@ -1,0 +1,89 @@
+package org.openpolicyagent.ideaplugin.ide.extensions
+
+import com.intellij.execution.actions.StopProcessAction
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.filters.TextConsoleBuilderFactory
+import com.intellij.execution.process.OSProcessHandler
+import com.intellij.execution.process.ProcessTerminatedListener
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowAnchor
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.ui.content.impl.ContentImpl
+import org.openpolicyagent.ideaplugin.opa.tool.OpaBaseTool
+import java.awt.BorderLayout
+import java.util.concurrent.ExecutionException
+import javax.swing.JPanel
+
+class OPAActionToolWindow {
+
+    val OPA_CONSOLE_ID = "OPA Console"
+    val OPA_CONSOLE_NAME = OPA_CONSOLE_ID
+    fun runProcessInConsole(project: Project, parameters: MutableList<String>, title: String) {
+        val commandLine = GeneralCommandLine()
+                .withExePath(OpaBaseTool.opaBinary)
+                .withWorkDirectory(project.basePath)
+                .withParameters(parameters)
+                .withCharset(Charsets.UTF_8)
+
+        try {
+            val processHandler = OSProcessHandler(commandLine)
+            ProcessTerminatedListener.attach(processHandler)
+
+            ApplicationManager.getApplication().invokeLater {
+                val consoleView = TextConsoleBuilderFactory.getInstance().createBuilder(project).console
+                consoleView.clear()
+                consoleView.attachToProcess(processHandler)
+                processHandler.startNotify()
+
+                val toolWindowManager = ToolWindowManager.getInstance(project)
+                var toolWindow = toolWindowManager.getToolWindow(OPA_CONSOLE_ID)
+
+                val panel = JPanel(BorderLayout())
+                panel.add(consoleView.component, "Center")
+                val toolbarActions = DefaultActionGroup()
+                toolbarActions.addAll(consoleView.createConsoleActions().copyOf().toList())
+                toolbarActions.add(StopProcessAction("Stop Process", "Stop Process", processHandler))
+                val toolbar = ActionManager.getInstance().createActionToolbar("unknown", toolbarActions, false)
+                toolbar.setTargetComponent(consoleView.component)
+
+                val consoleContent = ContentImpl(panel, title, false)
+
+
+                if (toolWindow != null) {
+                    val existing = toolWindow.contentManager.findContent(title) ?: null
+                    if (existing != null) {
+                        toolWindow.contentManager.removeContent(existing, true)
+                    }
+
+                    attachAndShowConsole(consoleContent, toolWindow)
+                    return@invokeLater
+                }
+
+                // Create and register the OPA window
+                toolWindow = toolWindowManager.registerToolWindow(OPA_CONSOLE_ID, true, ToolWindowAnchor.BOTTOM)
+                toolWindow.title = OPA_CONSOLE_NAME
+                toolWindow.stripeTitle = OPA_CONSOLE_NAME
+                toolWindow.isShowStripeButton = true
+                toolWindow.icon = AllIcons.Toolwindows.ToolWindowMessages
+
+                attachAndShowConsole(consoleContent, toolWindow)
+            }
+        } catch (e: ExecutionException) {
+            e.printStackTrace()
+        }
+    }
+
+    //helper to attach console window running porcess to opa tool window
+    private fun attachAndShowConsole(consoleContent: ContentImpl, toolWindow: ToolWindow){
+        consoleContent.manager = toolWindow.contentManager
+        toolWindow.contentManager.addContent(consoleContent)
+        toolWindow.contentManager.setSelectedContent(consoleContent)
+
+        toolWindow.show(null)
+    }
+}

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/opa/tool/OpaActions.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/opa/tool/OpaActions.kt
@@ -1,0 +1,57 @@
+package org.openpolicyagent.ideaplugin.opa.tool
+
+import com.intellij.codeInsight.hint.HintManager
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.calcRelativeToProjectPath
+import com.intellij.openapi.wm.ToolWindowManager
+import org.openpolicyagent.ideaplugin.ide.extensions.OPAActionToolWindow
+import org.openpolicyagent.ideaplugin.lang.psi.isRegoFile
+import org.openpolicyagent.ideaplugin.openapiext.virtualFile
+
+/**
+ * Utility class to format Rego file with opaFmt
+ *
+ * @see org.openpolicyagent.ideaplugin.ide.actions.CheckAction
+ */
+class OpaActions : OpaBaseTool() {
+
+    /**
+     * Opens window running opa test on the current file, or popup if current
+     * file is not a rego file
+     */
+
+    fun checkDocument(project: Project, document: Document, editor: Editor) {
+        val file = document.virtualFile
+        if (file != null && file.isRegoFile && file.isValid) {
+            val opaWindow = OPAActionToolWindow()
+            // todo: get path to file relative to project path
+            //  val path_to_file = calcRelativeToProjectPath(file, project)
+            val args = mutableListOf("check", file.name)
+            opaWindow.runProcessInConsole(project, args, "Opa Check")
+        } else {
+            //todo: currently it appears this does nothing :(
+            HintManager.getInstance().showErrorHint(editor, "Current file not valid or not Rego file")
+        }
+
+    }
+
+    /**
+     * Opens window running opa test --verbose on project directory
+     */
+     fun testWorkspace(project: Project, document: Document, editor: Editor) {
+            val opaWindow = OPAActionToolWindow()
+            val args = mutableListOf("test", ".", "--verbose")
+            opaWindow.runProcessInConsole(project, args, "Opa Test")
+            //todo: possibly check if project contains no rego files?
+    }
+
+    fun testWorkspaceCoverage(project: Project, document: Document, editor: Editor) {
+        val opaWindow = OPAActionToolWindow()
+        val args = mutableListOf("test", "--coverage", "--format=json", ".")
+        opaWindow.runProcessInConsole(project, args, "Opa Test Coverage")
+        //todo: possibly check if project contains no rego files?
+    }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -42,12 +42,12 @@
                   extensions="rego"/>
         <internalFileTemplate name="Rego File"/>
 
+        <!-- Highlighting -->
         <lang.parserDefinition language="rego"  implementationClass="org.openpolicyagent.ideaplugin.lang.parser.RegoParserDefinition"/>
         <lang.syntaxHighlighterFactory language="rego" implementationClass="org.openpolicyagent.ideaplugin.ide.highlight.RegoHighlighterFactory"/>
         <colorSettingsPage implementation="org.openpolicyagent.ideaplugin.ide.colors.RegoColorSettingsPage"/>
         <lang.commenter language="rego" implementationClass="org.openpolicyagent.ideaplugin.ide.commenter.RegoCommenter"/>
         <annotator language="rego" implementationClass="org.openpolicyagent.ideaplugin.ide.extensions.RegoHighlighterAnnotator"/>
-
 
         <configurationType implementation="org.openpolicyagent.ideaplugin.ide.runconfig.OpaEvalRunConfigurationType"/>
         <configurationType implementation="org.openpolicyagent.ideaplugin.ide.runconfig.test.OpaTestRunConfigurationType"/>
@@ -61,11 +61,35 @@
 
         <action id="org.openpolicyagent.ideaplugin.actions.FmtAction"
                 class="org.openpolicyagent.ideaplugin.ide.actions.FmtAction"
-                text="Reformat with Opa Fmt"
+                text="Reformat with opa fmt"
                 description="Reformat current file with Opa Fmt"
                 icon="AllIcons.Actions.RealIntentionBulb">
             <add-to-group group-id="CodeMenu" anchor="last"/>
             <keyboard-shortcut keymap="$default" first-keystroke="ctrl I"/>
+        </action>
+
+        <action id="org.openpolicyagent.ideaplugin.actions.CheckAction"
+                class="org.openpolicyagent.ideaplugin.ide.actions.CheckAction"
+                text="Check with opa check"
+                description="Check current file with Opa Check"
+                icon="AllIcons.Actions.RealIntentionBulb">
+            <add-to-group group-id="CodeMenu" anchor="before" relative-to-action="org.openpolicyagent.ideaplugin.actions.FmtAction"/>
+        </action>
+
+        <action id="org.openpolicyagent.ideaplugin.actions.TestAction"
+                class="org.openpolicyagent.ideaplugin.ide.actions.TestAction"
+                text="Test workspace with opa test"
+                description="Test workspace with opa test"
+                icon="AllIcons.Actions.RealIntentionBulb">
+            <add-to-group group-id="CodeMenu" anchor="before" relative-to-action="org.openpolicyagent.ideaplugin.actions.CheckAction"/>
+        </action>
+
+        <action id="org.openpolicyagent.ideaplugin.actions.TestCoverageAction"
+                class="org.openpolicyagent.ideaplugin.ide.actions.TestCoverageAction"
+                text="View test coverage for workspace with opa test --coverage"
+                description="View test coverage for workspace with opa test --coverage"
+                icon="AllIcons.Actions.RealIntentionBulb">
+            <add-to-group group-id="CodeMenu" anchor="before" relative-to-action="org.openpolicyagent.ideaplugin.actions.TestAction"/>
         </action>
 
         <action id="org.openpolicyagent.ideaplugin.ide.actions.RegoCreateFileAction"


### PR DESCRIPTION
-Created OpaActions utility class in opa.tool to hold implementation of actions rather than OpaCheck, OpaTest, etc files for each action piling up in opa.tool
-support for opa test, test coverage on project workspace and opa check on current open document, shows output in console window (all support for console window showing output is in extensions/OPAActionToolWindow)

fix #12 