### PR TITLE
launch configuration from gutter

### DIFF
--- a/docs/devel/architecture.md
+++ b/docs/devel/architecture.md
@@ -3,6 +3,7 @@
 - [Project structure](#project-structure)
 - [Lexer](#lexer)
 - [Parser](#parser)
+- [Useful methods](#useful-methods)
 - [Testing strategy](#testing-strategy)
   - [Tests resources](#tests-resources)
     - [Example](#example)
@@ -65,6 +66,14 @@ format. It looks like a `bnf` grammar. `Grammar kit` also generates the [PSI](ht
 Once the PSI is generated, some features like commenting code are really straightforward to implement.
 
 Code can be generated thanks to `generateRegoParser` gradle tasks.
+
+# Useful methods
+Some useful extension methods has been coded under:
+* [PsiElementExt.kt](../../src/main/kotlin/org/openpolicyagent/ideaplugin/lang/psi/PsiElementExt.kt)
+* [PsiFileExt.kt](../../src/main/kotlin/org/openpolicyagent/ideaplugin/lang/psi/PsiFileExt.kt)
+* [openapiext](../../src/main/kotlin/org/openpolicyagent/ideaplugin/openapiext)
+
+Please take a look.
 
 # Testing strategy
 As an introduction, we recommend reading the official [documentation](https://www.jetbrains.org/intellij/sdk/docs/basics/testing_plugins/testing_plugins.html).

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/linemarkers/OpaCommandRunLineMarker.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/linemarkers/OpaCommandRunLineMarker.kt
@@ -1,0 +1,76 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.openpolicyagent.ideaplugin.ide.linemarkers
+
+import com.intellij.execution.lineMarker.ExecutorAction
+import com.intellij.execution.lineMarker.RunLineMarkerContributor
+import com.intellij.icons.AllIcons
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.elementType
+import org.openpolicyagent.ideaplugin.lang.psi.*
+
+
+/**
+ * Add the marker in the gutter (ie the green arrow) to generate / run  RunConfiguration
+ *
+ * The RunConfiguration are generated / run by [org.openpolicyagent.ideaplugin.ide.runconfig.producer.OpaEvalRunConfigurationProducer]
+ * and [org.openpolicyagent.ideaplugin.ide.runconfig.test.producer.OpaTestRunConfigurationProducer]
+ *
+ * for more information see [com.intellij.codeInsight.daemon.LineMarkerProvider]
+ */
+class OpaCommandRunLineMarker : RunLineMarkerContributor() {
+    /**
+     * returns the marker Information for the [element] if available, null otherwise. if the marker information is null
+     * no marker will be created for this [element].
+     *
+     * We add markers for:
+     * - the package "line" in order to generate configuration to evaluate /test the package
+     * - the rule "line" in order to generate configuration to evaluate the rule or run this test rule
+     *
+     * Note: for performance reason marker must be placed on a leaf
+     *
+     * Implementation note:
+     *
+     * Marker must be placed on leaf (in our case ASCII_LETTER) so be careful if use PsiTreeUtil.getParentOfType() because
+     * a node may contains several ASCII_LETTER leaf. Consequently marker will be created for each leaf.
+     *
+     * Example:
+     * Package node may contains many ASCII_LETTER leafs.
+     *
+     * for "package test.main" we have the following psi tree
+     *
+     * RegoPackageImpl(RegoElementType.PACKAGE)
+     *      PsiElement(package)
+     *      RegoRefImpl(RegoElementType.REF)
+     *          RegoVarImpl(RegoElementType.VAR)
+     *              PsiElement(ASCII_LETTER) --> test
+     *          RegoRefArgImpl(RegoElementType.REF_ARG)
+     *              RegoRefArgDotImpl(RegoElementType.REF_ARG_DOT)
+     *                  PsiElement(.)
+     *                  RegoVarImpl(RegoElementType.VAR)
+     *                      PsiElement(ASCII_LETTER) --> main
+     *
+     *  So if we use PsiTreeUtil.getParentOfType(), we will have 2 markers for "test" and  "main" ASCII_LETTER leaf
+     */
+    override fun getInfo(element: PsiElement): Info? {
+        if (element.containingFile !is RegoFile) return null
+        if (element.elementType != RegoTypes.ASCII_LETTER) return null
+
+        val cmd = if (element.containingFile.isRegoTestFile()) "test" else "eval"
+
+        if (element.parent.parent.parent is RegoPackage) {
+            return Info(AllIcons.RunConfigurations.TestState.Run, { "$cmd package" }, ExecutorAction.getActions(1))
+        }
+
+        // todo element.parent is a VAR, in the grammar VAR is a simple rule is equals to token ASCII_LETTER, may be we should
+        // as VAR directly as a token to avoid this unnecessary node in the psi tree
+        if (element.parent.parent is RegoRuleHead) {
+            return Info(AllIcons.RunConfigurations.TestState.Run, { "$cmd rule" }, ExecutorAction.getActions(1))
+        }
+
+        return null
+    }
+}

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/OpaEvalRunConfiguration.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/OpaEvalRunConfiguration.kt
@@ -31,7 +31,7 @@ class OpaEvalRunConfiguration(
     project: Project,
     factory: ConfigurationFactory,
     name: String
-) : RunConfigurationBase<OpaEvalRunProfileState>(project, factory, name) {
+) : LocatableConfigurationBase<OpaEvalRunProfileState>(project, factory, name) {
 
     /**
      * the querry to evaluate
@@ -54,6 +54,10 @@ class OpaEvalRunConfiguration(
      */
     var additionalArgs: String? = null
 
+
+    override fun suggestedName(): String? {
+        return query
+    }
 
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration?> = OpaEvalRunCommandEditor(project)
 

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/OpaEvalRunConfigurationType.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/OpaEvalRunConfigurationType.kt
@@ -6,6 +6,7 @@ package org.openpolicyagent.ideaplugin.ide.runconfig
 
 import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.execution.configurations.ConfigurationType
+import com.intellij.execution.configurations.ConfigurationTypeUtil
 import org.openpolicyagent.ideaplugin.lang.RegoIcons
 import javax.swing.Icon
 
@@ -20,5 +21,10 @@ class OpaEvalRunConfigurationType : ConfigurationType {
     override fun getConfigurationTypeDescription(): String = "Opa eval"
     override fun getIcon(): Icon = RegoIcons.OPA
     override fun getConfigurationFactories(): Array<ConfigurationFactory> = arrayOf(OpaConfigurationFactory(this))
+
+    companion object {
+        fun getInstance(): OpaEvalRunConfigurationType =
+            ConfigurationTypeUtil.findConfigurationType(OpaEvalRunConfigurationType::class.java)
+    }
 }
 

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/producer/OpaEvalRunConfigurationProducer.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/producer/OpaEvalRunConfigurationProducer.kt
@@ -1,0 +1,69 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.openpolicyagent.ideaplugin.ide.runconfig.producer
+
+import com.intellij.execution.actions.ConfigurationContext
+import com.intellij.execution.actions.LazyRunConfigurationProducer
+import com.intellij.execution.configurations.ConfigurationFactory
+import com.intellij.openapi.util.Ref
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.openpolicyagent.ideaplugin.ide.runconfig.OpaConfigurationFactory
+import org.openpolicyagent.ideaplugin.ide.runconfig.OpaEvalRunConfiguration
+import org.openpolicyagent.ideaplugin.ide.runconfig.OpaEvalRunConfigurationType
+import org.openpolicyagent.ideaplugin.lang.psi.*
+import java.nio.file.Paths
+
+class OpaEvalRunConfigurationProducer : LazyRunConfigurationProducer<OpaEvalRunConfiguration>() {
+    override fun getConfigurationFactory(): ConfigurationFactory {
+        return OpaConfigurationFactory(OpaEvalRunConfigurationType.getInstance())
+    }
+
+    override fun isConfigurationFromContext(
+        configuration: OpaEvalRunConfiguration,
+        context: ConfigurationContext
+    ): Boolean {
+        val element = context.psiLocation
+        val regoPackage = element?.getRegoPackage() ?: return false
+
+        val (query, _) = queryAndOptions(element, regoPackage)
+        return configuration.query == query
+    }
+
+    override fun setupConfigurationFromContext(
+        configuration: OpaEvalRunConfiguration,
+        context: ConfigurationContext,
+        sourceElement: Ref<PsiElement>
+    ): Boolean {
+
+        val element = sourceElement.get()
+        if (! element.containingFile.isRegoSourceFile()) return false
+        val regoPackage = element.getRegoPackage() ?: return false
+
+
+        val (query, options) = queryAndOptions(element, regoPackage)
+
+        configuration.query = query
+        configuration.additionalArgs = "-f pretty $options"
+        configuration.name = configuration.query!!
+        return true
+    }
+
+    /**
+     * generate the query and option(as a Pair) to pass to `opa eval` command according to the PsiElement [element]. It can generate
+     * 2 types of queries
+     * <ul>
+     *     <li> eval for package with metrics enable (eg Pair<data.main,  --metrics>)
+     *     <li> eval a rule in a package (eg Pair<data.main.rule1, "">)
+     * </ul>
+     */
+    private fun queryAndOptions(element: PsiElement, regoPackage: RegoPackage?): Pair<String, String> {
+        if (element.parent.parent is RegoRuleHead) {
+            return Pair("data.${regoPackage?.ref?.text}.${element.text}", "")
+        }
+        return Pair("data.${regoPackage?.ref?.text}", "--metrics")
+    }
+}

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/OpaTestRunConfiguration.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/OpaTestRunConfiguration.kt
@@ -31,7 +31,7 @@ class OpaTestRunConfiguration(
     project: Project,
     factory: ConfigurationFactory,
     name: String
-) : RunConfigurationBase<OpaTestRunProfileState>(project, factory, name) {
+) : LocatableConfigurationBase<OpaTestRunProfileState>(project, factory, name) {
 
     /**
      * the bundle directory to pass to opa eval (ie option -b )

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/OpaTestRunConfigurationType.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/OpaTestRunConfigurationType.kt
@@ -7,6 +7,7 @@ package org.openpolicyagent.ideaplugin.ide.runconfig.test
 
 import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.execution.configurations.ConfigurationType
+import com.intellij.execution.configurations.ConfigurationTypeUtil
 import org.openpolicyagent.ideaplugin.ide.runconfig.OpaConfigurationFactory
 import org.openpolicyagent.ideaplugin.lang.RegoIcons
 import javax.swing.Icon
@@ -22,5 +23,11 @@ class OpaTestRunConfigurationType : ConfigurationType {
     override fun getConfigurationTypeDescription(): String = "Opa test"
     override fun getIcon(): Icon = RegoIcons.OPA
     override fun getConfigurationFactories(): Array<ConfigurationFactory> = arrayOf(OpaConfigurationFactory(this))
+
+    companion object {
+        fun getInstance(): OpaTestRunConfigurationType =
+            ConfigurationTypeUtil.findConfigurationType(OpaTestRunConfigurationType::class.java)
+    }
 }
+
 

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/producer/OpaTestRunConfigurationProducer.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/producer/OpaTestRunConfigurationProducer.kt
@@ -1,0 +1,62 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+
+package org.openpolicyagent.ideaplugin.ide.runconfig.test.producer
+
+import com.intellij.execution.actions.ConfigurationContext
+import com.intellij.execution.actions.LazyRunConfigurationProducer
+import com.intellij.execution.configurations.ConfigurationFactory
+import com.intellij.openapi.util.Ref
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.openpolicyagent.ideaplugin.ide.runconfig.OpaConfigurationFactory
+import org.openpolicyagent.ideaplugin.ide.runconfig.test.OpaTestRunConfiguration
+import org.openpolicyagent.ideaplugin.ide.runconfig.test.OpaTestRunConfigurationType
+import org.openpolicyagent.ideaplugin.lang.psi.*
+import java.nio.file.Paths
+
+class OpaTestRunConfigurationProducer : LazyRunConfigurationProducer<OpaTestRunConfiguration>() {
+    override fun getConfigurationFactory(): ConfigurationFactory {
+        return OpaConfigurationFactory(OpaTestRunConfigurationType.getInstance())
+    }
+
+    override fun isConfigurationFromContext(
+        configuration: OpaTestRunConfiguration,
+        context: ConfigurationContext
+    ): Boolean {
+        val element = context.psiLocation
+        val regoPackage = element?.getRegoPackage() ?: return false
+
+        return configuration.additionalArgs?.matches(Regex(".*${getRunOption(element, regoPackage)}( .*|\$)")) ?: false
+    }
+
+    override fun setupConfigurationFromContext(
+        configuration: OpaTestRunConfiguration,
+        context: ConfigurationContext,
+        sourceElement: Ref<PsiElement>
+    ): Boolean {
+        val element = sourceElement.get()
+        if (! element.containingFile.isRegoTestFile()) return false
+        val regoPackage = element.getRegoPackage() ?: return false
+
+
+        configuration.additionalArgs = "-f pretty  ${getRunOption(element, regoPackage)}"
+        configuration.name = element.text
+        return true
+    }
+
+
+    /**
+     * generate the run option to pass to opa eval. This option allow to filter the test to execute by passing a regex
+     * matching the test names.
+     */
+    private fun getRunOption(element: PsiElement, regoPackage: RegoPackage?): String {
+        if (element.parent.parent is RegoRuleHead) {
+            return "-r data.${regoPackage?.ref?.text}.${element.text}"
+        }
+        return "-r data.${regoPackage?.ref?.text}"
+    }
+}

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/lang/psi/PsiElementExt.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/lang/psi/PsiElementExt.kt
@@ -1,0 +1,24 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.openpolicyagent.ideaplugin.lang.psi
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+
+/**
+ * return the [org.openpolicyagent.ideaplugin.lang.psi.RegoPackage] of the file or null if the file is not a
+ * [org.openpolicyagent.ideaplugin.lang.psi.RegoFile] or does not contains a regoPackage
+ */
+fun PsiElement.getRegoPackage(): RegoPackage?{
+    if (containingFile is RegoFile) {
+        return PsiTreeUtil.findChildOfType(containingFile, RegoPackage::class.java)
+    }
+    return null
+}
+
+
+inline fun <reified T : PsiElement> PsiElement.ancestorOrSelf(): T? =
+    PsiTreeUtil.getParentOfType(this, T::class.java, /* strict */ false)

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/lang/psi/PsiFileExt.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/lang/psi/PsiFileExt.kt
@@ -1,0 +1,22 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.openpolicyagent.ideaplugin.lang.psi
+
+import com.intellij.psi.PsiFile
+
+/**
+ * Return [true] if the file is a rego test file (ie containing tests), [false] otherwise
+ */
+fun PsiFile.isRegoTestFile() : Boolean{
+    return this is RegoFile && name.startsWith("test_")
+}
+
+/**
+ * Return [true] if the file is a rego source file (ie not containing tests), [false] otherwise
+ */
+fun PsiFile.isRegoSourceFile() : Boolean{
+    return this is RegoFile && ! name.startsWith("test_")
+}

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/openapiext/ElementExt.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/openapiext/ElementExt.kt
@@ -8,7 +8,9 @@
 package org.openpolicyagent.ideaplugin.openapiext
 
 import com.intellij.execution.ExternalizablePath
+import com.intellij.openapi.util.JDOMUtil
 import org.jdom.Element
+import org.jdom.input.SAXBuilder
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -38,3 +40,7 @@ fun Element.writePath(name: String, value: Path?) {
 fun Element.readPath(name: String): Path? {
     return readString(name)?.let { Paths.get(ExternalizablePath.localPathValue(it)) }
 }
+
+fun Element.toXmlString() = JDOMUtil.writeElement(this)
+
+fun elementFromXmlString(xml: String): Element =    SAXBuilder().build(xml.byteInputStream()).rootElement

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/openapiext/utils.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/openapiext/utils.kt
@@ -140,10 +140,6 @@ inline fun <Key, reified Psi : PsiElement> getElements(
     StubIndex.getElements(indexKey, key, project, scope, Psi::class.java)
 
 
-fun Element.toXmlString() = JDOMUtil.writeElement(this)
-fun elementFromXmlString(xml: String): org.jdom.Element =
-    SAXBuilder().build(xml.byteInputStream()).rootElement
-
 class CachedVirtualFile(private val url: String?) {
     private val cache = AtomicReference<VirtualFile>()
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -52,6 +52,11 @@
         <configurationType implementation="org.openpolicyagent.ideaplugin.ide.runconfig.OpaEvalRunConfigurationType"/>
         <configurationType implementation="org.openpolicyagent.ideaplugin.ide.runconfig.test.OpaTestRunConfigurationType"/>
 
+        <runConfigurationProducer implementation="org.openpolicyagent.ideaplugin.ide.runconfig.producer.OpaEvalRunConfigurationProducer" />
+        <runConfigurationProducer implementation="org.openpolicyagent.ideaplugin.ide.runconfig.test.producer.OpaTestRunConfigurationProducer" />
+
+        <runLineMarkerContributor language="rego" implementationClass="org.openpolicyagent.ideaplugin.ide.linemarkers.OpaCommandRunLineMarker"/>
+
         <!-- TODOs -->
         <todoIndexer filetype="Rego file" implementationClass="org.openpolicyagent.ideaplugin.ide.todo.RegoLexerBasedTodoIndexer"/>
         <indexPatternBuilder implementation="org.openpolicyagent.ideaplugin.ide.todo.RegoTodoIndexPatternBuilder"/>

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/OpaTestBase.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/OpaTestBase.kt
@@ -16,7 +16,7 @@ abstract class OpaTestBase : BasePlatformTestCase(), OpaTestCase {
     protected val fileName: String
         get() = "$testName.rego"
 
-    private val testName: String
+    protected val testName: String
         get() = camelOrWordsToSnake(getTestName(true))
 
     companion object {
@@ -27,4 +27,7 @@ abstract class OpaTestBase : BasePlatformTestCase(), OpaTestCase {
             return name.split("(?=[A-Z])".toRegex()).joinToString("_", transform = String::toLowerCase)
         }
     }
+
+    protected fun FileTree.create(): TestProject =
+        create(myFixture.project, myFixture.findFileInTempDir("."))
 }

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/linemarkers/OpaCommandRunLineMarkerTest.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/linemarkers/OpaCommandRunLineMarkerTest.kt
@@ -8,7 +8,7 @@ package org.openpolicyagent.ideaplugin.ide.linemarkers
 
 class OpaCommandRunLineMarkerTest : OpaLineMarkerProviderTestBase() {
 
-    fun `test eval markers on rego file`() = doTestByText("main.rego","""
+    fun `test 'eval' markers on rego file`() = doTestByText("main.rego","""
        package main # - eval package
         hello { # - eval rule
             m == "world"
@@ -19,7 +19,7 @@ class OpaCommandRunLineMarkerTest : OpaLineMarkerProviderTestBase() {
         }
     """)
 
-    fun `test test makers on rego test file`() = doTestByText("test_main.rego" , """
+    fun `test 'test' makers on rego test file`() = doTestByText("test_main.rego" , """
         package test.main # - test package
         test_main { # - test rule
             a==b

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/linemarkers/OpaCommandRunLineMarkerTest.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/linemarkers/OpaCommandRunLineMarkerTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.openpolicyagent.ideaplugin.ide.linemarkers
+
+
+class OpaCommandRunLineMarkerTest : OpaLineMarkerProviderTestBase() {
+
+    fun `test eval markers on rego file`() = doTestByText("main.rego","""
+       package main # - eval package
+        hello { # - eval rule
+            m == "world"
+        }
+        
+        warn[msg]{ # - eval rule
+            a == b
+        }
+    """)
+
+    fun `test test makers on rego test file`() = doTestByText("test_main.rego" , """
+        package test.main # - test package
+        test_main { # - test rule
+            a==b
+        }
+        
+        test_main_2 { # - test rule
+            a==b
+        }
+    """.trimIndent())
+
+}

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/linemarkers/OpaLineMarkerProviderTestBase.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/linemarkers/OpaLineMarkerProviderTestBase.kt
@@ -1,0 +1,58 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.openpolicyagent.ideaplugin.ide.linemarkers
+
+import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import org.intellij.lang.annotations.Language
+import org.openpolicyagent.ideaplugin.FileTree
+import org.openpolicyagent.ideaplugin.OpaTestBase
+
+abstract class OpaLineMarkerProviderTestBase : OpaTestBase() {
+    protected fun doTestByText(filename: String, @Language("rego") source: String) {
+        myFixture.configureByText(filename, source)
+        myFixture.doHighlighting()
+        val expected = markersFrom(source)
+        val actual = markersFrom(myFixture.editor, myFixture.project)
+        assertEquals(expected.joinToString(COMPARE_SEPARATOR), actual.joinToString(COMPARE_SEPARATOR))
+    }
+
+    protected fun doTestFromFile(filePath: String, fileTree: FileTree) {
+        fileTree.create()
+        myFixture.configureFromTempProjectFile(filePath)
+        myFixture.doHighlighting()
+        val expected = markersFrom(myFixture.editor.document.text)
+        val actual = markersFrom(myFixture.editor, myFixture.project)
+        assertEquals(expected.joinToString(COMPARE_SEPARATOR), actual.joinToString(COMPARE_SEPARATOR))
+    }
+
+    private fun markersFrom(text: String) =
+        text.split('\n')
+            .withIndex()
+            .filter { it.value.contains(MARKER) }
+            .map { Pair(it.index, it.value.substring(it.value.indexOf(MARKER) + MARKER.length).trim()) }
+
+    private fun markersFrom(editor: Editor, project: Project) =
+        DaemonCodeAnalyzerImpl.getLineMarkers(editor.document, project)
+            .map {
+                Pair(editor.document.getLineNumber(it.element?.textRange?.startOffset as Int),
+                    it.lineMarkerTooltip)
+            }
+            .sortedBy { it.first }
+
+    private companion object {
+        /**
+         * Special comment that contains the tooltip of the expected marker
+         */
+        const val MARKER = "# - "
+
+        /**
+         * this separator is used when several marker  are present in the file
+         */
+        const val COMPARE_SEPARATOR = " | "
+    }
+}

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/producer/OpaEvalRunConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/producer/OpaEvalRunConfigurationProducerTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.openpolicyagent.ideaplugin.ide.runconfig.producer
+
+
+class OpaEvalRunConfigurationProducerTest : RunConfigurationProducerTestBase() {
+
+    fun `test eval producer should generate config to eval complex rule`() {
+
+        testProject {
+            file(
+                "main.rego", """
+                    package main.abc.efg
+
+                    rule_1 { # caret:0
+                        input.a == "b"
+                        1 == 1
+                    }
+                """.trimIndent()
+            ).open()
+
+        }
+        checkOnLeaf()
+    }
+
+    fun `test eval should generate config to eval eval simple rule`() {
+        testProject {
+            file(
+                "main.rego", """
+                    package main.abc.efg
+                    
+                    api_version_mgs_tmpl = "%s %s - use deprecated apiversion '%s'.This api will be remove in kubernetes v1.16." # caret:0
+
+
+                    rule_1 { 
+                        input.a == "b"
+                    }
+                """.trimIndent()
+            ).open()
+
+        }
+        checkOnLeaf()
+    }
+
+    fun `test eval producer should generate config to eval package`() {
+        testProject {
+            file(
+                "main.rego", """
+                    package main # caret:0
+
+                    rule_1 
+                    { 
+                        input.a == "b"
+                    }
+                """.trimIndent()
+            ).open()
+        }
+        checkOnLeaf()
+    }
+}

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/producer/RunConfigurationProducerTestBase.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/producer/RunConfigurationProducerTestBase.kt
@@ -1,0 +1,125 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+// This class is borrow from https://github.com/intellij-rust/intellij-rust/blob/6a4626c5d6cf66050893d10517125fbda77a218c/src/test/kotlin/org/rust/cargo/runconfig/producers/RunConfigurationProducerTestBase.kt#L35
+// and adapted to fit the project
+package org.openpolicyagent.ideaplugin.ide.runconfig.producer
+
+import com.intellij.execution.actions.ConfigurationContext
+import com.intellij.psi.PsiElement
+import org.intellij.lang.annotations.Language
+import org.jdom.Element
+import org.openpolicyagent.ideaplugin.OpaTestBase
+import org.openpolicyagent.ideaplugin.lang.psi.ancestorOrSelf
+import org.openpolicyagent.ideaplugin.openapiext.toXmlString
+
+abstract class RunConfigurationProducerTestBase : OpaTestBase() {
+
+    override val dataPath = "org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures"
+
+
+    protected fun checkOnLeaf() = checkOnElement<PsiElement>()
+
+    private inline fun <reified T : PsiElement> checkOnElement() {
+        val configurationContext = ConfigurationContext(
+            myFixture.file.findElementAt(myFixture.caretOffset)?.ancestorOrSelf<T>()
+        )
+        check(configurationContext)
+    }
+
+    protected fun openFileInEditor(path: String) {
+        myFixture.configureFromExistingVirtualFile(myFixture.findFileInTempDir(path))
+    }
+
+
+    private fun check(configurationContext: ConfigurationContext) {
+        val configurations = configurationContext.configurationsFromContext.orEmpty().map { it.configuration }
+
+        val serialized = configurations.map { config ->
+            Element("configuration").apply {
+                setAttribute("name", config.name)
+                setAttribute("class", config.javaClass.simpleName)
+                config.writeExternal(this)
+            }
+        }
+
+        val root = Element("configurations")
+        serialized.forEach { root.addContent(it) }
+
+
+        assertSameLinesWithFile("$testDataPath/${testName}.xml", root.toXmlString())
+    }
+
+
+    protected fun testProject(description: TestProjectBuilder.() -> Unit) {
+        val testProject = TestProjectBuilder()
+        testProject.description()
+        testProject.build()
+    }
+
+    protected inner class TestProjectBuilder {
+        private inner class File(
+            val path: String,
+            val code: String,
+            val caretOffset: Int?
+        )
+
+        private var files = arrayListOf<File>()
+        private var toOpen: File? = null
+
+
+        fun file(path: String, @Language("rego") code: String): TestProjectBuilder {
+            addFile(path, code)
+            return this
+        }
+
+        fun open(): TestProjectBuilder {
+            require(toOpen == null)
+            toOpen = files.last()
+            return this
+        }
+
+        fun build() {
+            myFixture.addFileToProject(
+                "Cargo.toml", """
+                [project]
+                name = "test"
+                version = 0.0.1
+            """
+            )
+            files.forEach { myFixture.addFileToProject(it.path, it.code) }
+            toOpen?.let { toOpen ->
+                openFileInEditor(toOpen.path)
+                if (toOpen.caretOffset != null) {
+                    myFixture.editor.caretModel.moveToOffset(toOpen.caretOffset)
+                }
+            }
+
+        }
+
+
+        private fun addFile(path: String, code: String): File {
+            val matchResult = Regex("# caret:([0-9]+)").find(code)
+
+            var offset :Int?= null
+            if (matchResult != null) {
+                val caretOffset = matchResult.groupValues[1].toInt()
+
+                var i = code.indexOf("# caret:")
+                while (i > 0 && code[i] != '\n') {
+                    i--
+                }
+
+                // if i> 0 then code[i] = '\n', so wee add one to get the first char of the line
+                val lineStartIdx = if (i > 0) i + 1 else i
+
+                offset = lineStartIdx + caretOffset
+            }
+
+            val cleanedCode = code.replace(Regex("# caret:[0-9]+"), "")
+            return File(path, cleanedCode, offset).also { files.add(it) }
+        }
+    }
+}

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/OpaTestRunConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/OpaTestRunConfigurationProducerTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.openpolicyagent.ideaplugin.ide.runconfig.test
+
+import org.openpolicyagent.ideaplugin.ide.runconfig.producer.RunConfigurationProducerTestBase
+
+
+class OpaTestRunConfigurationProducerTest : RunConfigurationProducerTestBase() {
+    fun `test test producer should generate config for test rule `() {
+
+        testProject {
+            file(
+                "test_main.rego", """
+                    package test.main.abc.efg
+
+                    test_1 { # caret:0
+                        1 == 1
+                    }
+
+                """.trimIndent()
+            ).open()
+
+        }
+        checkOnLeaf()
+    }
+
+    fun `test test producer should generate config to test package`() {
+
+        testProject {
+            file(
+                "test_main.rego", """
+                    package main.abc.efg # caret:0
+                    
+                    test_ rule_1 { 
+                        input.a == "b"
+                    }
+                """.trimIndent()
+            ).open()
+
+        }
+        checkOnLeaf()
+    }
+}

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/lang/RegoParsingTestCaseBase.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/lang/RegoParsingTestCaseBase.kt
@@ -11,7 +11,6 @@ import org.openpolicyagent.ideaplugin.OpaTestCase
 import org.openpolicyagent.ideaplugin.OpaTestCase.Companion.testResourcesPath
 import org.openpolicyagent.ideaplugin.lang.parser.RegoParserDefinition
 import org.openpolicyagent.ideaplugin.openapiext.execute
-import java.util.concurrent.ExecutionException
 import com.intellij.execution.configurations.GeneralCommandLine
 import org.openpolicyagent.ideaplugin.opa.tool.OpaBaseTool.Companion.opaBinary
 

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/lang/psi/PsiElementExtKtTest.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/lang/psi/PsiElementExtKtTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.openpolicyagent.ideaplugin.lang.psi
+
+import com.intellij.json.JsonFileType
+import org.openpolicyagent.ideaplugin.OpaTestBase
+import org.openpolicyagent.ideaplugin.lang.RegoFileType
+import org.assertj.core.api.Assertions.assertThat
+
+class PsiElementExtKtTest: OpaTestBase() {
+
+    fun `test getRegoPackage returns null if file is not a rego file`(){
+        val file = myFixture.configureByText(JsonFileType(),"""
+            {"a": "b"}
+        """.trimIndent())
+
+        assertThat(file.lastChild.getRegoPackage()).isNull()
+
+    }
+
+    fun `test getRegoPackage returns null if file does not contains a rego package`(){
+        val file = myFixture.configureByText(RegoFileType,"""
+            rule_1{
+                1 == 2
+            }
+        """.trimIndent())
+
+        assertThat(file.lastChild.getRegoPackage()).isNull()
+    }
+
+    fun `test getRegoPackage returns the rego package if file is rego file and contains a package`(){
+        val file = myFixture.configureByText(RegoFileType,"""
+            package main
+            
+            rule_1{
+                1 == 2
+            }
+        """.trimIndent())
+
+        assertThat(file.lastChild.getRegoPackage()).isInstanceOf(RegoPackage::class.java)
+    }
+}

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/lang/psi/PsiFileExtKtTest.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/lang/psi/PsiFileExtKtTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.openpolicyagent.ideaplugin.lang.psi
+import com.intellij.json.JsonFileType
+import org.assertj.core.api.Assertions.assertThat
+
+
+import org.openpolicyagent.ideaplugin.OpaTestBase
+
+class PsiFileExtKtTest : OpaTestBase(){
+    companion object {
+        const val REGO_SOURCE_FILE_NAME = "main.rego"
+        val  REGO_SOURCE_FILE_CONTENT = """
+            package main
+            
+            rule_1{
+                1 == 1
+            }
+        """.trimIndent()
+
+        const val REGO_TEST_FILE_NAME = "test_main.rego"
+        val  REGO_TEST_FILE_CONTENT = """
+            package test.main
+            
+            test_rule_1{
+                1 == 1
+            }
+        """.trimIndent()
+
+    }
+
+    fun `test isRegoSourceFile returns true when file is rego source file`(){
+        val file= myFixture.configureByText( REGO_SOURCE_FILE_NAME, REGO_SOURCE_FILE_CONTENT)
+        assertThat(file.isRegoSourceFile()).isTrue()
+    }
+
+    fun `test isRegoSourceFile returns false when file is rego test file`(){
+        val file= myFixture.configureByText( REGO_TEST_FILE_NAME, REGO_TEST_FILE_CONTENT)
+        assertThat(file.isRegoSourceFile()).isFalse()
+    }
+
+    fun `test isRegoSourceFile returns false when file is not a Rego file`(){
+        val file= myFixture.configureByText(JsonFileType(),"""
+            {"a": "b"}
+        """.trimIndent())
+        assertThat(file.isRegoSourceFile()).isFalse()
+    }
+
+    fun `test isRegoTestFile returns true when file is rego test file`(){
+        val file= myFixture.configureByText(REGO_TEST_FILE_NAME, REGO_TEST_FILE_CONTENT)
+        assertThat(file.isRegoTestFile()).isTrue()
+    }
+
+    fun `test isRegoTestFile returns false when file is rego source file`(){
+        val file= myFixture.configureByText(REGO_SOURCE_FILE_NAME, REGO_SOURCE_FILE_CONTENT)
+        assertThat(file.isRegoTestFile()).isFalse()
+    }
+
+    fun `test isRegoTestFile returns false when file is not a Rego file`(){
+        val file= myFixture.configureByText(JsonFileType(),"""
+            {"a": "b"}
+        """.trimIndent())
+        assertThat(file.isRegoTestFile()).isFalse()
+    }
+}

--- a/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures/eval_producer_should_generate_config_to_eval_complex_rule.xml
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures/eval_producer_should_generate_config_to_eval_complex_rule.xml
@@ -1,0 +1,6 @@
+<configurations>
+  <configuration name="data.main.abc.efg.rule_1" class="OpaEvalRunConfiguration">
+    <option name="query" value="data.main.abc.efg.rule_1" />
+    <option name="addtionalargs" value="-f pretty " />
+  </configuration>
+</configurations>

--- a/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures/eval_producer_should_generate_config_to_eval_package.xml
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures/eval_producer_should_generate_config_to_eval_package.xml
@@ -1,0 +1,6 @@
+<configurations>
+  <configuration name="data.main" class="OpaEvalRunConfiguration">
+    <option name="query" value="data.main" />
+    <option name="addtionalargs" value="-f pretty --metrics" />
+  </configuration>
+</configurations>

--- a/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures/eval_should_generate_config_to_eval_eval_simple_rule.xml
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures/eval_should_generate_config_to_eval_eval_simple_rule.xml
@@ -1,0 +1,6 @@
+<configurations>
+  <configuration name="data.main.abc.efg.api_version_mgs_tmpl" class="OpaEvalRunConfiguration">
+    <option name="query" value="data.main.abc.efg.api_version_mgs_tmpl" />
+    <option name="addtionalargs" value="-f pretty " />
+  </configuration>
+</configurations>

--- a/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures/test_producer_should_generate_config_for_test_rule.xml
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures/test_producer_should_generate_config_for_test_rule.xml
@@ -1,0 +1,5 @@
+<configurations>
+  <configuration name="test_1" class="OpaTestRunConfiguration">
+    <option name="addtionalargs" value="-f pretty  -r data.test.main.abc.efg.test_1" />
+  </configuration>
+</configurations>

--- a/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures/test_producer_should_generate_config_to_test_package.xml
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/producer/fixtures/test_producer_should_generate_config_to_test_package.xml
@@ -1,0 +1,5 @@
+<configurations>
+  <configuration name="package" class="OpaTestRunConfiguration">
+    <option name="addtionalargs" value="-f pretty  -r data.main.abc.efg" />
+  </configuration>
+</configurations>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting your PR, some kind reminder

* If this is your first PR, please read our contributor guidelines: https://github.com/vgramer/opa-idea-plugin/blob/master/CONTRIBUTING.md

* Code should be accompanied by tests whenever it's possible.

* New feature must be documented

For more information about the project architecture please take a look at https://github.com/vgramer/opa-idea-plugin/tree/master/docs/devel

-->

# Description
create LineRunMaker(green arrow)  on package and RuleHead. And 2 run configuration producer (one for eval and one for test) to create/edit the associated configuration

Most of the logic has been coded but some corner cases must still be addressed and tests must be added.
 
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`

If you just want to link an issue but not automatically close it, use `Ref #<issue number>` instead of  `Fixes`
-->
Fixes #28 #9 

# Special notes for your reviewer
It still in progress but if you want to test it. you must either comment or adapt these lines 
[OpaEvalRunConfigurationProducer.kt#L65-L66](https://github.com/vgramer/opa-idea-plugin/blob/4acdb35f6d80f5fd8b6d0a32aff715357982ba33/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/producer/OpaEvalRunConfigurationProducer.kt#L65-L66)
[OpaTestRunConfigurationProducer.kt#L59](https://github.com/vgramer/opa-idea-plugin/blob/4acdb35f6d80f5fd8b6d0a32aff715357982ba33/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/runconfig/test/producer/OpaTestRunConfigurationProducer.kt#L59)