### PR TITLE
OpaTestRunConfiguration: add the full output of the command to the root node

### DIFF
--- a/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/test/runner_all_test_error/[root].regex
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/test/runner_all_test_error/[root].regex
@@ -1,0 +1,14 @@
+Testing started at .+
+opa test \-f pretty \-v \-b .+
+
+data.test.main.test_rule1_should_raise_error: ERROR \([^)]+\)  [^:]+:8: eval_builtin_error: to_number: strconv.ParseFloat: parsing "rule1": invalid syntax
+
+
+data.test.main.test_rule2_should_raise_error: ERROR \([^)]+\)  [^:]+:12: eval_builtin_error: to_number: strconv.ParseFloat: parsing "rule2": invalid syntax
+
+
+data.test.main.test_3_should_raise_error: ERROR \([^)]+\)  [^:]+:16: eval_builtin_error: to_number: strconv.ParseFloat: parsing "test3": invalid syntax
+
+ERROR: 3\/3
+
+Process finished with exit code 2

--- a/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/test/runner_with_all_tests_fail/[root].regex
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/test/runner_with_all_tests_fail/[root].regex
@@ -1,0 +1,33 @@
+Testing started at .+
+opa test \-f pretty \-v \-b .+
+FAILURES
+\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-
+
+data.test.main.test_rule1_should_be_ko: FAIL \([^)]+\)
+  query:1                                                              Enter data.test.main.test_rule1_should_be_ko = _
+  [^:]+:5     \| Enter data.test.main.test_rule1_should_be_ko
+  [^:]+:7     \| \| Fail msg = \{"should fail test 1"}
+  query:1                                                              \| Fail data.test.main.test_rule1_should_be_ko = _
+
+
+
+data.test.main.test_rule_2_should_be_ko: FAIL \([^)]+\)
+  query:1                                                              Enter data.test.main.test_rule_2_should_be_ko = _
+  [^:]+:10     \| Enter data.test.main.test_rule_2_should_be_ko
+  [^:]+:12     \| \| Fail msg = \{"another message in order to put the test in FAIL state"}
+  query:1                                                              \| Fail data.test.main.test_rule_2_should_be_ko = _
+
+
+
+data.test.main.test_should_fail: FAIL \([^)]+\)
+  query:1                                                              Enter data.test.main.test_should_fail = _
+  [^:]+:15     \| Enter data.test.main.test_should_fail
+  [^:]+:16     \| \| Fail 2 = 1
+  query:1                                                              \| Fail data.test.main.test_should_fail = _
+
+
+\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-
+\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-
+FAIL: 3\/3
+
+Process finished with exit code 2

--- a/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/test/runner_with_test_error_pass_and_fail/[root].regex
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/test/runner_with_test_error_pass_and_fail/[root].regex
@@ -1,0 +1,22 @@
+Testing started at .+
+opa test \-f pretty \-v \-b .+
+FAILURES
+\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-
+
+data.test.main.test_rule_2_should_be_ko: FAIL \([^)]+\)
+  query:1                                                              Enter data.test.main.test_rule_2_should_be_ko = _
+  [^:]+:16     \| Enter data.test.main.test_rule_2_should_be_ko
+  [^:]+:18     \| \| Fail msg = \{"another message in order to put the test in FAIL state"\}
+  query:1                                                              \| Fail data.test.main.test_rule_2_should_be_ko = _
+
+
+\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-
+
+data.test.main.test_should_raise_error: ERROR \([^)]+\)  [^:]+:8: eval_builtin_error: to_number: strconv.ParseFloat: parsing "x": invalid syntax
+
+\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-
+PASS: 1\/3
+FAIL: 1\/3
+ERROR: 1\/3
+
+Process finished with exit code 2

--- a/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/test/runner_with_test_pass_fail_and_error/[root].regex
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/ide/runconfig/test/runner_with_test_pass_fail_and_error/[root].regex
@@ -1,0 +1,21 @@
+Testing started at .+
+opa test \-f pretty \-v \-b .+
+FAILURES
+\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-
+
+data.test.main.test_rule_2_should_be_ko: FAIL \(.+\)
+  query:1                                                              Enter data.test.main.test_rule_2_should_be_ko = _
+  [^:]+:9      \| Enter data.test.main.test_rule_2_should_be_ko
+  [^:]+:11     \| \| Fail msg = \{"another message in order to put the test in FAIL state"}
+  query:1                                                              \| Fail data.test.main.test_rule_2_should_be_ko = _
+
+
+\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-
+
+data.test.main.test_should_raise_error: ERROR \([^)]+\)  [^:]+:18: eval_builtin_error: to_number: strconv.ParseFloat: parsing "x": invalid syntax
+
+PASS: 1\/3
+FAIL: 1\/3
+ERROR: 1\/3
+
+Process finished with exit code 2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting your PR, some kind reminder

* If this is your first PR, please read our contributor guidelines: https://github.com/vgramer/opa-idea-plugin/blob/master/CONTRIBUTING.md

* Code should be accompanied by tests whenever it's possible.

* New feature must be documented

For more information about the project architecture please take a look at https://github.com/vgramer/opa-idea-plugin/tree/master/docs/devel

-->

# Description
Print the executed command and the full output on the root node.

## before
<img width="1446" alt="before" src="https://user-images.githubusercontent.com/1167539/94020727-89bc1700-fdb3-11ea-94fb-7d49060da40d.png">

## after
<img width="1446" alt="after" src="https://user-images.githubusercontent.com/1167539/94020768-96d90600-fdb3-11ea-97ba-677c9e39550a.png">
<img width="1729" alt="after-2" src="https://user-images.githubusercontent.com/1167539/94021294-254d8780-fdb4-11ea-998e-473af58e24e9.png">

 
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`

If you just want to link an issue but not automatically close it, use `Ref #<issue number>` instead of  `Fixes`
-->
Fixes #51 

# Special notes for your reviewer

<!-- if your notes are small enough, you can directly comment your PR in the review section --> 