### PR TITLE
fix grammar: access to function's return value without assigning it to a variable

### DIFF
--- a/src/main/grammar/Rego.bnf
+++ b/src/main/grammar/Rego.bnf
@@ -77,7 +77,7 @@ literal         ::= ( some-decl | expr | "not" expr )  with-modifier*
 with-modifier   ::= "with" term "as" term
 some-decl       ::= "some" var ( "," var )*
 expr            ::=  expr2  ((':=' | '=') expr2)?
-expr2           ::=  expr-infix | expr-call   | term
+expr2           ::=  expr-infix | (expr-call ref-arg*)  | term
 expr-call       ::= var ref-arg-dot* "(" ( term ( "," term )* )? ")"
 expr-infix      ::= ( term "=" )? term infix-operator term
 term            ::= ref | var | scalar | array | object | set | array-compr | object-compr | set-compr

--- a/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/functions.rego
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/functions.rego
@@ -33,3 +33,21 @@ q(1, x) = y {
 q(2, x) = y {
     y := x*4
 }
+
+fun_obj(x) = h {
+    h := {"a": {"b":  [x,2]}}
+}
+
+fun_array(x) = j {
+    j:= [{"a": [x,2]}]
+}
+aRule {
+    # testing we can acces to the function's return value without assigning it to a variable. Issue #57
+    a = fun_obj(1).a
+    b = fun_obj(1).a.b
+    c = fun_obj(1).a.b[0]
+
+    k = fun_array(1)[0]
+    l = fun_array(1)[0].a
+    m = fun_array(1)[0].a[0]
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting your PR, some kind reminder

* If this is your first PR, please read our contributor guidelines: https://github.com/vgramer/opa-idea-plugin/blob/master/CONTRIBUTING.md

* Code should be accompanied by tests whenever it's possible.

* New feature must be documented

For more information about the project architecture please take a look at https://github.com/vgramer/opa-idea-plugin/tree/master/docs/devel

-->

# Description
In rego this rule is valid:

```rego
fun_obj(x) = h {
    h := {"a": {"b":  [x,2]}}
}

aRule {
    a = fun_obj(1).a
}
```
 but with the current grammar, nothing is allowed after an `expr-call`. So for your parser, this rule is not valid.

To fix that, we allow to have zero or more `ref-arg` (ie `"." var` or `"[" ( scalar | var | array | object | set | "_" ) "]"` => the accesor to an object or an array) after an `expr-call`

<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`

If you just want to link an issue but not automatically close it, use `Ref #<issue number>` instead of  `Fixes`
-->
Fixes #57 

# Special notes for your reviewer

<!-- if your notes are small enough, you can directly comment your PR in the review section --> 