### PR TITLE
fix grammar: Operator inside of function args was reported as error

### DIFF
--- a/src/main/grammar/Rego.bnf
+++ b/src/main/grammar/Rego.bnf
@@ -64,41 +64,42 @@
         COMMENT             = 'regexp:[ \t]*#[^\r\n]*'
     ]
 }
-module          ::= package import*  policy
-package         ::= "package" ref
-import          ::= "import" ref ( "as" var )?
-policy          ::=  rule*
-rule            ::=  "default"?  rule-head  rule-body*
-rule-head       ::= var ( "(" rule-args? ")" )? ("[" term "]" )? ( ( ":=" | "=" ) term )?
-rule-args       ::= term ( "," term )*
-rule-body       ::= ( else ( "=" term )? )? "{" query "}"
-query           ::=( literal |';' )+
-literal         ::= ( some-decl | expr | "not" expr )  with-modifier*
-with-modifier   ::= "with" term "as" term
-some-decl       ::= "some" var ( "," var )*
-expr            ::=  expr2  ((':=' | '=') expr2)?
-expr2           ::=  expr-infix | (expr-call ref-arg*)  | term
-expr-call       ::= var ref-arg-dot* "(" ( term ( "," term )* )? ")"
-expr-infix      ::= ( term "=" )? term infix-operator term
-term            ::= ref | var | scalar | array | object | set | array-compr | object-compr | set-compr
-array-compr     ::= "[" term "|" query "]"
-set-compr       ::= "{" term "|" query "}"
-object-compr    ::= "{" object-item "|" query "}"
-infix-operator  ::= bool-operator | arith-operator | bin-operator
-bool-operator   ::= "==" | "!=" | "<" | ">" | ">=" | "<="
-arith-operator  ::= "+" | "-" | "*" | "/" | "%"
-bin-operator    ::= "&" | "|"
-ref             ::= ( expr-call  | array | object | set | array-compr | object-compr | set-compr |var  )  ref-arg*
-ref-arg         ::= ref-arg-dot | ref-arg-brack
-ref-arg-brack   ::= "[" ( scalar | var | array | object | set | "_" ) "]"
-ref-arg-dot     ::= "." var
-var             ::= ASCII_LETTER
-scalar          ::= string | NUMBER | TRUE | FALSE | NULL
-string          ::= STRING_TOKEN| RAW_STRING
-array           ::= '[' term? ( ',' term )* ','? ']'
-object          ::= '{' object-item? ( ',' object-item )* ','? '}'
-object-item     ::= ( scalar | ref | var ) ":" term
-set             ::= empty-set | non-empty-set
-non-empty-set   ::= "{" term ( "," term )* ','?  "}"
-empty-set       ::= "set(" ")"
+module              ::= package import*  policy
+package             ::= "package" ref
+import              ::= "import" ref ( "as" var )?
+policy              ::=  rule*
+rule                ::=  "default"?  rule-head  rule-body*
+rule-head           ::= var ( "(" rule-args? ")" )? ("[" term "]" )? ( ( ":=" | "=" ) term )?
+rule-args           ::= term ( "," term )*
+rule-body           ::= ( else ( "=" term )? )? "{" query "}"
+query               ::=( literal |';' )+
+literal             ::= ( some-decl | expr | "not" expr )  with-modifier*
+with-modifier       ::= "with" term "as" term
+some-decl           ::= "some" var ( "," var )*
+expr                ::=  expr2  ((':=' | '=') expr2)?
+expr2               ::=  expr-infix | (expr-call ref-arg*)  | term
+term-or-infix-op    ::= term (infix-operator term)?
+expr-call           ::= var ref-arg-dot* "(" ( term-or-infix-op ( "," term-or-infix-op )* )? ")"
+expr-infix          ::= ( term "=" )? term infix-operator term
+term                ::= ref | var | scalar | array | object | set | array-compr | object-compr | set-compr
+array-compr         ::= "[" term "|" query "]"
+set-compr           ::= "{" term "|" query "}"
+object-compr        ::= "{" object-item "|" query "}"
+infix-operator      ::= bool-operator | arith-operator | bin-operator
+bool-operator       ::= "==" | "!=" | "<" | ">" | ">=" | "<="
+arith-operator      ::= "+" | "-" | "*" | "/" | "%"
+bin-operator        ::= "&" | "|"
+ref                 ::= ( expr-call  | array | object | set | array-compr | object-compr | set-compr |var  )  ref-arg*
+ref-arg             ::= ref-arg-dot | ref-arg-brack
+ref-arg-brack       ::= "[" ( scalar | var | array | object | set | "_" ) "]"
+ref-arg-dot         ::= "." var
+var                 ::= ASCII_LETTER
+scalar              ::= string | NUMBER | TRUE | FALSE | NULL
+string              ::= STRING_TOKEN| RAW_STRING
+array               ::= '[' term? ( ',' term )* ','? ']'
+object              ::= '{' object-item? ( ',' object-item )* ','? '}'
+object-item         ::= ( scalar | ref | var ) ":" term
+set                 ::= empty-set | non-empty-set
+non-empty-set       ::= "{" term ( "," term )* ','?  "}"
+empty-set           ::= "set(" ")"
 

--- a/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/functions.rego
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/functions.rego
@@ -51,3 +51,16 @@ aRule {
     l = fun_array(1)[0].a
     m = fun_array(1)[0].a[0]
 }
+
+filterFunc(x) {
+   true
+}
+
+testing_complex_function_args{
+    # testing accectiing infix operation as arg. Issue #63
+    x := count({"x"} & {"y"})
+
+    # testing "complex" args
+    myset := {1, 2, 3}
+    array.slice([1, 2, 3, 4 ], count({x | myset[x]; filterFunc(x)} & {2}), 3)
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting your PR, some kind reminder

* If this is your first PR, please read our contributor guidelines: https://github.com/vgramer/opa-idea-plugin/blob/master/CONTRIBUTING.md

* Code should be accompanied by tests whenever it's possible.

* New feature must be documented

For more information about the project architecture please take a look at https://github.com/vgramer/opa-idea-plugin/tree/master/docs/devel

-->

# Description
Fix bug in grammar that does not allow to use of infix operation as argument of a function 

Example:
This expression was reported as an error
```
ARule(){
       x := count({x} & {y})
}
```
Also, add a test to check that function arg ca  be a complex expression (eg set comprehension, function call...)
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`

If you just want to link an issue but not automatically close it, use `Ref #<issue number>` instead of  `Fixes`
-->
Fixes #63 

# Special notes for your reviewer

<!-- if your notes are small enough, you can directly comment your PR in the review section --> 