### PR TITLE
refactor RegoHighlighterAnnotator to make it testable

### DIFF
--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/colors/RegoColors.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/colors/RegoColors.kt
@@ -5,6 +5,7 @@
 
 package org.openpolicyagent.ideaplugin.ide.colors
 
+import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.options.colors.AttributesDescriptor
@@ -42,4 +43,8 @@ enum class RegoColor(humanName: String, val default: TextAttributesKey? = null) 
 
     val textAttributesKey = TextAttributesKey.createTextAttributesKey("org.openpolicyagent.ideaplugin.$name", default)
     val attributesDescriptor = AttributesDescriptor(humanName, textAttributesKey)
+
+    // create a new severity with the name of the rego color. It useful to test highlighting.
+    // see [org.openpolicyagent.ideaplugin.ide.highlight.AnnotatorTestBase.setUp] for more information
+    val testSeverity: HighlightSeverity = HighlightSeverity(name, HighlightSeverity.INFORMATION.myVal)
 }

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/RegoHighlighterAnnotator.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/RegoHighlighterAnnotator.kt
@@ -8,57 +8,37 @@ package org.openpolicyagent.ideaplugin.ide.highlight
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.lang.annotation.HighlightSeverity
-import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.psi.PsiElement
 import org.openpolicyagent.ideaplugin.ide.colors.RegoColor
-import org.openpolicyagent.ideaplugin.lang.psi.*
+import org.openpolicyagent.ideaplugin.lang.psi.RegoEmptySet
+import org.openpolicyagent.ideaplugin.lang.psi.RegoExprCall
+import org.openpolicyagent.ideaplugin.lang.psi.RegoRule
+import org.openpolicyagent.ideaplugin.openapiext.isUnitTestMode
 
 class RegoHighlighterAnnotator : Annotator {
-
-    private fun styleForDeclType(definition: Any) = when (definition) {
-        is RegoRule -> RegoColor.HEAD
-        is RegoExprCall -> RegoColor.CALL
-        is RegoEmptySet -> RegoColor.CALL
-        else -> null
-    }
-
-    //todo: better way to record colors used in annotator?
+    // visibility for Testing
     val usedColors = listOf(RegoColor.HEAD.textAttributesKey, RegoColor.CALL.textAttributesKey)
 
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
-        if (element is RegoRule){
-            val style = styleForDeclType(element)
-            if (style != null){
-                holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
-                    .range(element.ruleHead.`var`.textRange)
-                    .textAttributes( style.textAttributesKey)
-                    .create()
-            }
-        }
+        val (style, range) = when (element) {
+            is RegoRule -> Pair(RegoColor.HEAD, element.ruleHead.`var`.textRange)
 
-        if (element is RegoExprCall){
-            val style = styleForDeclType(element)
-            if (style != null){
+            is RegoEmptySet -> Pair(RegoColor.CALL, element.textRange)
+
+            is RegoExprCall -> {
                 val varlist = element.refArgDotList
-                val textRange = if(varlist.size >= 1) varlist[varlist.size - 1].`var`.textRange else element.`var`.textRange
-
-                holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
-                    .range(textRange)
-                    .textAttributes( style.textAttributesKey)
-                    .create()
+                val textRange = if (varlist.size >= 1) varlist[varlist.size - 1].`var`.textRange else element.`var`.textRange
+                Pair(RegoColor.CALL, textRange)
             }
 
-        }
+            else -> null
+        } ?: return
 
-        if (element is RegoEmptySet){
-            val style = styleForDeclType(element)
-            if (style != null){
-                holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
-                    .range(element)
-                    .textAttributes( style.textAttributesKey)
-                    .create()
-            }
-        }
+        val severity = if (isUnitTestMode) style.testSeverity else HighlightSeverity.INFORMATION
 
+        holder.newSilentAnnotation(severity)
+            .range(range)
+            .textAttributes(style.textAttributesKey)
+            .create()
     }
 }

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/lang/psi/RegoFile.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/lang/psi/RegoFile.kt
@@ -9,7 +9,6 @@ import com.intellij.extapi.psi.PsiFileBase
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.FileViewProvider
-import com.intellij.psi.PsiElement
 import org.openpolicyagent.ideaplugin.lang.RegoFileType
 import org.openpolicyagent.ideaplugin.lang.RegoLanguage
 

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/AnnotatorTestBase.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/AnnotatorTestBase.kt
@@ -1,0 +1,94 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.openpolicyagent.ideaplugin.ide.highlight
+
+import com.intellij.codeInsight.daemon.impl.SeveritiesProvider
+import org.intellij.lang.annotations.Language
+import org.openpolicyagent.ideaplugin.OpaTestBase
+import org.openpolicyagent.ideaplugin.ide.colors.RegoColor
+
+abstract class AnnotatorTestBase: OpaTestBase() {
+    /**
+     * override setup to add register  RegoColor names has new severities. It allow us to test text is correctly
+     * highlighted. for more information see [check_info]
+     *
+     */
+    override fun setUp() {
+        super.setUp()
+        val testSeverityProvider = TestSeverityProvider(RegoColor.values().map(RegoColor::testSeverity))
+        // BACKCOMPAT: 2020.1
+        SeveritiesProvider.EP_NAME.getPoint(null).registerExtension(testSeverityProvider, testRootDisposable)
+    }
+
+    /**
+     * Check annotation with info severity
+     * Example:
+     * ```
+     * fun `test function call is highlighted`() {
+     *    check_info( """
+     *        package  <info descr="Some message">main</info>
+     *        a:= "hello"
+     *    """.trimIndent())
+     * }
+     * ```
+     *
+     * If you want to test silent Annotation (used for highlight some text like rule name of function call), you should
+     * use the name of the RegoColor
+     *
+     * ```
+     * fun `test function call is highlighted`() {
+     *    check_info( """
+     *        package main
+     *        <HEAD>aRule</HEAD> {
+     *              a = <CALL>fun_obj</CALL>(1).a
+     *        }
+     *    """.trimIndent())
+     * }
+     * ```
+     */
+    fun check_info(@Language("rego") text: String){
+        check(text, false, true, false, false)
+    }
+
+    /**
+     * Check annotation with warn severity
+     * Example:
+     * ```
+     * fun `test warn annotation`() {
+     *    check_info( """
+     *        package  <warn descr="Some message">main</warn>
+     *        a:= "hello"
+     *    """.trimIndent())
+     * }
+     * ```
+     */
+    fun check_warn(@Language("rego") text: String){
+        check(text, true, false, true, false)
+    }
+
+    /**
+     * check annotation with `error` severity
+     *
+     * Example:
+     * ```
+     * fun `test unclosed string is reported as error`() {
+     *    check_error( """
+     *        package  main
+     *        a:= <error descr="Missing closing quote">"</error>
+     *    """.trimIndent())
+     * }
+     * ```
+     */
+    fun check_error(@Language("rego") text: String){
+        check(text, false, false, false, false)
+    }
+
+    private fun check(text: String, checkWarnings: Boolean, checkInfos: Boolean, checkWeakWarnings: Boolean, ignoreExtraHighlighting: Boolean){
+        myFixture.configureByText("main.rego", text)
+        myFixture.checkHighlighting(checkWarnings, checkInfos, checkWeakWarnings, ignoreExtraHighlighting)
+    }
+
+}

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/RegoHighlighterAnnotatorTest.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/RegoHighlighterAnnotatorTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.openpolicyagent.ideaplugin.ide.highlight
+
+
+class RegoHighlighterAnnotatorTest : AnnotatorTestBase() {
+    fun `test rule name is highlighted`() {
+        check_info( """
+            package  main
+            <HEAD>a</HEAD>:= "hello"
+            
+            <HEAD>hostnames</HEAD>[name] { name := sites[_].servers[_].hostname }
+            
+        """.trimIndent())
+    }
+
+    fun `test function call is highlighted`() {
+        check_info( """
+            package  main
+            <HEAD>aRule</HEAD> {
+                a = <CALL>fun_obj</CALL>(1).a
+            }
+            
+        """.trimIndent())
+    }
+
+    fun `test empty set is highlighted`() {
+        check_info("""
+            package  main
+            <HEAD>a</HEAD> := <CALL>set()</CALL>
+            
+        """.trimIndent())
+    }
+}

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/TestSeverityProvider.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/TestSeverityProvider.kt
@@ -1,0 +1,30 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+// borrow to https://github.com/intellij-rust/intellij-rust/blob/master/common/src/test/kotlin/com/intellij/ide/annotator/TestSeverityProvider.kt
+package org.openpolicyagent.ideaplugin.ide.highlight
+
+import com.intellij.codeInsight.daemon.impl.HighlightInfoType
+import com.intellij.codeInsight.daemon.impl.SeveritiesProvider
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.psi.PsiElement
+
+/**
+ * Register new Severity for annotation. It allow to test the Highlighting of salient annotation
+ * see [org.openpolicyagent.ideaplugin.ide.highlight.AnnotatorTestBase.setUp] for more information
+ */
+class TestSeverityProvider(private val severities: List<HighlightSeverity>) : SeveritiesProvider() {
+    override fun getSeveritiesHighlightInfoTypes(): List<HighlightInfoType> = severities.map(::TestHighlightingInfoType)
+}
+
+private class TestHighlightingInfoType(private val severity: HighlightSeverity) : HighlightInfoType {
+    override fun getAttributesKey(): TextAttributesKey = DEFAULT_TEXT_ATTRIBUTES
+    override fun getSeverity(psiElement: PsiElement?): HighlightSeverity = severity
+
+    companion object {
+        private val DEFAULT_TEXT_ATTRIBUTES = TextAttributesKey.createTextAttributesKey("DEFAULT_TEXT_ATTRIBUTES")
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting your PR, some kind reminder

* If this is your first PR, please read our contributor guidelines: https://github.com/vgramer/opa-idea-plugin/blob/master/CONTRIBUTING.md

* Code should be accompanied by tests whenever it's possible.

* New feature must be documented

For more information about the project architecture please take a look at https://github.com/vgramer/opa-idea-plugin/tree/master/docs/devel

-->

# Description
This Pr refactor and add tests on `RegoHighlighterAnnotator` 

Register RegoColors as new severities in order to test silent annotations
 
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`

If you just want to link an issue but not automatically close it, use `Ref #<issue number>` instead of  `Fixes`
-->

# Special notes for your reviewer

<!-- if your notes are small enough, you can directly comment your PR in the review section --> 