### PR TITLE
Fix grammar multiline quote

### DIFF
--- a/src/main/grammar/Rego.bnf
+++ b/src/main/grammar/Rego.bnf
@@ -54,13 +54,12 @@
         QUOTIENT            = '/'
         REMAINDER           = '%'
         SET_OPEN            = 'set('
-        BACKSTRICK          = '`'
         NULL                = 'null'
         ASCII_LETTER        = 'regexp:[A-Za-z_][A-Za-z_0-9]*'
         NUMBER              = 'regexp:-?(0|[1-9]\d*)(\.\d+)?([eE][+-]?\d*)?'
         WHITE_SPACE         = 'regexp:\s+'
-        STRING_TOKEN        = 'regexp:"([^"\]|\\.)*"'
-        RAW_STRING          = 'regexp:`[^`]*`'
+        STRING_TOKEN        = 'regexp:"([^\r\n"])*"?'
+        RAW_STRING          = 'regexp:`[^`]*(`)?'
         COMMENT             = 'regexp:[ \t]*#[^\r\n]*'
     ]
 }

--- a/src/main/grammar/RegoLexer.flex
+++ b/src/main/grammar/RegoLexer.flex
@@ -28,10 +28,13 @@ WHITE_SPACE=\s+
 ASCII_LETTER=[A-Za-z_][A-Za-z_0-9]*
 NUMBER=-?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][+-]?[0-9]*)?
 WHITE_SPACE=[ \t\n\x0B\f\r]+
-STRING_TOKEN=\"([^\"\\]|\\.)*\"
-RAW_STRING=`[^`]*`
-COMMENT=[ \t]*#[^\r\n]*
 
+//The closing quote is optional in order to have a valid token, so the quoteHandler can autoclose it
+//if the user don't close the quote, an error will be reported by the RegoSyntaxErrorAnnotator
+STRING_TOKEN=\"([^\r\n\"])*\"?
+RAW_STRING=`[^`]*(`)?
+
+COMMENT=[ \t]*#[^\r\n]*
 
 %%
 <YYINITIAL> {
@@ -73,7 +76,6 @@ COMMENT=[ \t]*#[^\r\n]*
   "/"                 { return QUOTIENT; }
   "%"                 { return REMAINDER; }
   "set("              { return SET_OPEN; }
-  "`"                 { return BACKSTRICK; }
   "null"              { return NULL; }
 
   {ASCII_LETTER}      { return ASCII_LETTER; }

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/AnnotatorBase.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/AnnotatorBase.kt
@@ -1,0 +1,50 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+// borrow to https://github.com/intellij-rust/intellij-rust/blob/master/common/src/main/kotlin/com/intellij/ide/annotator/AnnotatorBase.kt
+package org.openpolicyagent.ideaplugin.ide.highlight
+
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.Annotator
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.util.Disposer
+import com.intellij.psi.PsiElement
+import com.intellij.util.containers.ContainerUtil
+import org.jetbrains.annotations.TestOnly
+import org.openpolicyagent.ideaplugin.openapiext.isUnitTestMode
+
+/**
+ * Abstract annotator that add annotation only if
+ *  * it not run in test mode
+ *  * it run in test and annotator is registered by testing class
+ *
+ * It simplify the tests because only the class under test adds annotations. So in test output, we get only the highlighting
+ * of the class under test.
+ */
+abstract class AnnotatorBase : Annotator {
+
+    final override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+        if (!isUnitTestMode || javaClass in enabledAnnotators) {
+            annotateInternal(element, holder)
+        }
+    }
+
+    /**
+     * Annotates the specified PSI element.
+     * for more info see [com.intellij.lang.annotation.Annotator.annotate]
+     */
+    protected abstract fun annotateInternal(element: PsiElement, holder: AnnotationHolder)
+
+    companion object {
+        private val enabledAnnotators: MutableSet<Class<out AnnotatorBase>> = ContainerUtil.newConcurrentSet()
+
+        @TestOnly
+        fun enableAnnotator(annotatorClass: Class<out AnnotatorBase>, parentDisposable: Disposable) {
+            enabledAnnotators += annotatorClass
+            Disposer.register(parentDisposable, Disposable { enabledAnnotators -= annotatorClass })
+        }
+    }
+}

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/RegoHighlighterAnnotator.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/RegoHighlighterAnnotator.kt
@@ -15,11 +15,11 @@ import org.openpolicyagent.ideaplugin.lang.psi.RegoExprCall
 import org.openpolicyagent.ideaplugin.lang.psi.RegoRule
 import org.openpolicyagent.ideaplugin.openapiext.isUnitTestMode
 
-class RegoHighlighterAnnotator : Annotator {
+class RegoHighlighterAnnotator : AnnotatorBase() {
     // visibility for Testing
     val usedColors = listOf(RegoColor.HEAD.textAttributesKey, RegoColor.CALL.textAttributesKey)
 
-    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+    override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
         val (style, range) = when (element) {
             is RegoRule -> Pair(RegoColor.HEAD, element.ruleHead.`var`.textRange)
 

--- a/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/RegoSyntaxErrorAnnotator.kt
+++ b/src/main/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/RegoSyntaxErrorAnnotator.kt
@@ -1,0 +1,34 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.openpolicyagent.ideaplugin.ide.highlight
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.psi.PsiElement
+import org.openpolicyagent.ideaplugin.lang.psi.RegoString
+
+class RegoSyntaxErrorAnnotator : AnnotatorBase() {
+    override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
+        if (element is RegoString) {
+            element.stringToken?.let {
+                val text = it.text
+
+                // Check that double quoted string is closed properly
+                if (text.length <= 1 || text[0] != text[text.length - 1] || text[text.length - 2] == '\\') {
+                    holder.newAnnotation(HighlightSeverity.ERROR, "Missing closing quote").create()
+                }
+            }
+            element.rawString?.let {
+                val text = it.text
+
+                // Check that raw string  is closed properly
+                if (text.length <= 1 || text[0] != text[text.length - 1]) {
+                    holder.newAnnotation(HighlightSeverity.ERROR, "Missing closing backtick").create()
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/opa-core.xml
+++ b/src/main/resources/META-INF/opa-core.xml
@@ -19,7 +19,10 @@
         <lang.syntaxHighlighterFactory language="rego" implementationClass="org.openpolicyagent.ideaplugin.ide.highlight.RegoHighlighterFactory"/>
         <colorSettingsPage implementation="org.openpolicyagent.ideaplugin.ide.colors.RegoColorSettingsPage"/>
         <lang.commenter language="rego" implementationClass="org.openpolicyagent.ideaplugin.ide.commenter.RegoCommenter"/>
+
+        <!-- Annotator -->
         <annotator language="rego" implementationClass="org.openpolicyagent.ideaplugin.ide.highlight.RegoHighlighterAnnotator"/>
+        <annotator language="rego" implementationClass="org.openpolicyagent.ideaplugin.ide.highlight.RegoSyntaxErrorAnnotator"/>
 
         <configurationType implementation="org.openpolicyagent.ideaplugin.ide.runconfig.OpaEvalRunConfigurationType"/>
         <configurationType implementation="org.openpolicyagent.ideaplugin.ide.runconfig.test.OpaTestRunConfigurationType"/>

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/AnnotatorTestBase.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/AnnotatorTestBase.kt
@@ -9,15 +9,19 @@ import com.intellij.codeInsight.daemon.impl.SeveritiesProvider
 import org.intellij.lang.annotations.Language
 import org.openpolicyagent.ideaplugin.OpaTestBase
 import org.openpolicyagent.ideaplugin.ide.colors.RegoColor
+import kotlin.reflect.KClass
 
-abstract class AnnotatorTestBase: OpaTestBase() {
+abstract class AnnotatorTestBase(private val annotatorClass: KClass<out AnnotatorBase>): OpaTestBase() {
     /**
      * override setup to add register  RegoColor names has new severities. It allow us to test text is correctly
      * highlighted. for more information see [check_info]
      *
+     * Also enable only the annotator [annotatorClass]. For more informationn see [org.openpolicyagent.ideaplugin.ide.highlight.AnnotatorBase]
      */
     override fun setUp() {
         super.setUp()
+        AnnotatorBase.enableAnnotator(annotatorClass.java, testRootDisposable)
+
         val testSeverityProvider = TestSeverityProvider(RegoColor.values().map(RegoColor::testSeverity))
         // BACKCOMPAT: 2020.1
         SeveritiesProvider.EP_NAME.getPoint(null).registerExtension(testSeverityProvider, testRootDisposable)

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/RegoHighlighterAnnotatorTest.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/RegoHighlighterAnnotatorTest.kt
@@ -6,7 +6,7 @@
 package org.openpolicyagent.ideaplugin.ide.highlight
 
 
-class RegoHighlighterAnnotatorTest : AnnotatorTestBase() {
+class RegoHighlighterAnnotatorTest : AnnotatorTestBase(RegoHighlighterAnnotator::class) {
     fun `test rule name is highlighted`() {
         check_info( """
             package  main

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/RegoSyntaxErrorAnnotatorTest.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/ide/highlight/RegoSyntaxErrorAnnotatorTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Use of this source code is governed by the MIT license that can be
+ * found in the LICENSE file.
+ */
+
+package org.openpolicyagent.ideaplugin.ide.highlight
+
+class RegoSyntaxErrorAnnotatorTest : AnnotatorTestBase(RegoSyntaxErrorAnnotator::class){
+
+    fun `test unclosed string is reported as error`(){
+        check_error("""
+            package main
+            a:= <error descr="Missing closing quote">"hello</error>
+        """.trimIndent())
+    }
+
+    fun `test unclosed string with only one char is reported as error`(){
+        check_error("""
+            package main
+            a:= <error descr="Missing closing quote">"</error>
+        """.trimIndent())
+    }
+
+    fun `test unclosed string with only escape char is reported as error`(){
+        check_error("""
+            package main
+            a:= <error descr="Missing closing quote">"\"</error>
+        """.trimIndent())
+    }
+
+    fun `test no error are reported for valid string`(){
+        check_error("""
+            package main
+            a:= "hello world"
+        """.trimIndent())
+    }
+
+    fun `test no error are reported for valid string containing escape`(){
+        check_error("""
+            package main
+            a:= "hello \”world"
+        """.trimIndent())
+    }
+
+    fun `test no error are reported for empty string`(){
+        check_error("""
+            package main
+            a:= ""
+        """.trimIndent())
+    }
+
+    fun `test unclosed raw_string is reported as error`(){
+        check_error("""
+            package main
+            a:= <error descr="Missing closing backtick">`hello</error>
+        """.trimIndent())
+    }
+
+    fun `test unclosed multi-line raw_string is reported as error`(){
+        check_error("""
+            package main
+            a:= <error descr="Missing closing backtick">`hello
+            
+            world</error>
+        """.trimIndent())
+    }
+
+    fun `test unclosed raw_string with only one char is reported as error`(){
+        check_error("""
+            package main
+            a:= <error descr="Missing closing backtick">`</error>
+        """.trimIndent())
+    }
+
+    fun `test no error are reported for valid raw_string`(){
+        check_error("""
+            package main
+            a:= `hello world`
+        """.trimIndent())
+    }
+
+    fun `test no error are reported for valid multi-line raw_string`(){
+        check_error("""
+            package main
+            a:= `hello 
+            
+            world`
+        """.trimIndent())
+    }
+
+    fun `test no error are reported for empty raw_string`(){
+        check_error("""
+            package main
+            a:= ``
+        """.trimIndent())
+    }
+}

--- a/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/strings.rego
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/strings.rego
@@ -6,3 +6,7 @@ someRule {
 }
 
 someString := `hello\there`
+
+multiLineRawString := `hello
+world
+`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting your PR, some kind reminder

* If this is your first PR, please read our contributor guidelines: https://github.com/vgramer/opa-idea-plugin/blob/master/CONTRIBUTING.md

* Code should be accompanied by tests whenever it's possible.

* New feature must be documented

For more information about the project architecture please take a look at https://github.com/vgramer/opa-idea-plugin/tree/master/docs/devel

-->

# Description
## fix grammar: string should not be multi-line
In lexer, the closing quote for the string is optional in order to have a valid token, so the quoteHandler can autoclose it
if the user doesn't close the quote, an error will be reported by the RegoSyntaxErrorAnnotator
   

## refactor annotators to be able to test only one at the time
Introduce abstract class AnnotatorBase that adds annotation only if test mode is disabled or annotator is registered by the class under test. It allows having only the highlighting produce by the class under test in the test output

 
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`

If you just want to link an issue but not automatically close it, use `Ref #<issue number>` instead of  `Fixes`
-->
Fixes #

# Special notes for your reviewer

PR #73   need to be merge before in order to pass the tests. in the meantime this PR is draft