### PR TITLE
grammar: fix rule-head and expr-infix

### DIFF
--- a/src/main/grammar/Rego.bnf
+++ b/src/main/grammar/Rego.bnf
@@ -68,7 +68,7 @@ package             ::= "package" ref
 import              ::= "import" ref ( "as" var )?
 policy              ::=  rule*
 rule                ::=  "default"?  rule-head  rule-body*
-rule-head           ::= var ( "(" rule-args? ")" )? ("[" term "]" )? ( ( ":=" | "=" ) term )?
+rule-head           ::= var ( "(" rule-args? ")" )? ("[" term "]" )? ( ( ":=" | "=" ) expr2 )?
 rule-args           ::= term ( "," term )*
 rule-body           ::= ( else ( "=" term )? )? "{" query "}"
 query               ::=( literal |';' )+
@@ -79,7 +79,7 @@ expr                ::=  expr2  ((':=' | '=') expr2)?
 expr2               ::=  expr-infix | (expr-call ref-arg*)  | term
 term-or-infix-op    ::= term (infix-operator term)?
 expr-call           ::= var ref-arg-dot* "(" ( term-or-infix-op ( "," term-or-infix-op )* )? ")"
-expr-infix          ::= ( term "=" )? term infix-operator term
+expr-infix          ::= term infix-operator term (infix-operator term)*
 term                ::= ref | var | scalar | array | object | set | array-compr | object-compr | set-compr
 array-compr         ::= "[" term "|" query "]"
 set-compr           ::= "{" term "|" query "}"

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/lang/RegoParsingTestCase.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/lang/RegoParsingTestCase.kt
@@ -33,6 +33,7 @@ class RegoParsingTestCase: RegoParsingTestCaseBase() {
     fun `test functions`() = doTestNoError()
     fun `test multiple expressions`() = doTestNoError()
     fun `test rules`() = doTestNoError()
+    fun `test rule head`() = doTestNoError()
     fun `test self joins`() = doTestNoError()
     fun `test with keyword 2`() = doTestNoError()
 

--- a/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/built_in_functions.rego
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/built_in_functions.rego
@@ -25,6 +25,7 @@ numbers {
     z2 := x * y
     z3 := x / y
     z4 := x % y
+    z5 := z + z1 - z2 * z3 / z4 % 3
     output := round(x)
     output1 := abs(x)
     output2 := count(collection_or_string)
@@ -55,6 +56,8 @@ sets {
     s3 := s1 & s2
     s4 := s1 | s2
     s5 := s1 - s2
+    s6 := s1 | s2 | s3 & s4 - s5
+
     output := intersection(set[set])
     output1 := union(set[set])
 }

--- a/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/rule_head.rego
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/rule_head.rego
@@ -1,0 +1,18 @@
+package test
+
+a1 := {1,2,3}
+a2 := {3}
+a3 := {4}
+array1:=[1, 2]
+array2:=[3]
+
+
+
+output1 := array.concat(array1, array2)
+
+# issue #70
+b := a1 | a2 | a3
+c := a1 & a2 | a3 - b
+
+d := 1+2 - array.concat(array1, array2)[2]
+e := array.concat(array1, array2)[0] + array.concat(array1, array2)[1]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting your PR, some kind reminder

* If this is your first PR, please read our contributor guidelines: https://github.com/vgramer/opa-idea-plugin/blob/master/CONTRIBUTING.md

* Code should be accompanied by tests whenever it's possible.

* New feature must be documented

For more information about the project architecture please take a look at https://github.com/vgramer/opa-idea-plugin/tree/master/docs/devel

-->

# Description
Fix  the `rule-head` and `expr-infix`in the grammar

## rule-head:
Only `term` was accepted in `rule-head`. Consequently, the following rule was invalid:
`a:= 1 + 2`

## expr-infix:
There were 2 problems:
* assignment was valid inside affectation (eg `a := b =  1 + 2`)
* only one infix operation was accepted. Consequently, this expression `a := 1 + 2 +3` was invalid
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`

If you just want to link an issue but not automatically close it, use `Ref #<issue number>` instead of  `Fixes`
-->
Fixes #70

