### PR TITLE
Fix grammar: allow import between rules and  complex expression in else statement

### DIFF
--- a/src/main/grammar/Rego.bnf
+++ b/src/main/grammar/Rego.bnf
@@ -69,7 +69,7 @@ import              ::= "import" ref ( "as" var )?
 rule                ::=  "default"?  rule-head  rule-body*
 rule-head           ::= var ( "(" rule-args? ")" )? ("[" term "]" )? ( ( ":=" | "=" ) expr2 )?
 rule-args           ::= term ( "," term )*
-rule-body           ::= ( else ( "=" term )? )? "{" query "}"
+rule-body           ::= ( else ( "=" expr2 )? )? "{" query "}"
 query               ::=( literal |';' )+
 literal             ::= ( some-decl | expr | "not" expr )  with-modifier*
 with-modifier       ::= "with" term "as" term

--- a/src/main/grammar/Rego.bnf
+++ b/src/main/grammar/Rego.bnf
@@ -63,10 +63,9 @@
         COMMENT             = 'regexp:[ \t]*#[^\r\n]*'
     ]
 }
-module              ::= package import*  policy
+module              ::= package (import|  rule)*
 package             ::= "package" ref
 import              ::= "import" ref ( "as" var )?
-policy              ::=  rule*
 rule                ::=  "default"?  rule-head  rule-body*
 rule-head           ::= var ( "(" rule-args? ")" )? ("[" term "]" )? ( ( ":=" | "=" ) expr2 )?
 rule-args           ::= term ( "," term )*

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/lang/RegoParsingTestCase.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/lang/RegoParsingTestCase.kt
@@ -40,7 +40,6 @@ class RegoParsingTestCase: RegoParsingTestCaseBase() {
 
     fun `test composite keys`() = doTestNoError()
     fun `test composite values`() = doTestNoError()
-    fun `test else keyword 2`() = doTestNoError()
 
     fun `test imports`() = doTestNoError()
     fun `test imports between rules`() = doTestNoError()

--- a/src/test/kotlin/org/openpolicyagent/ideaplugin/lang/RegoParsingTestCase.kt
+++ b/src/test/kotlin/org/openpolicyagent/ideaplugin/lang/RegoParsingTestCase.kt
@@ -41,7 +41,10 @@ class RegoParsingTestCase: RegoParsingTestCaseBase() {
     fun `test composite keys`() = doTestNoError()
     fun `test composite values`() = doTestNoError()
     fun `test else keyword 2`() = doTestNoError()
+
     fun `test imports`() = doTestNoError()
+    fun `test imports between rules`() = doTestNoError()
+
     fun `test negations`() = doTestNoError()
     fun `test package with simple rule`() = doTestNoError()
     fun `test references`() = doTestNoError()

--- a/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/else_keyword.rego
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/else_keyword.rego
@@ -1,4 +1,45 @@
 package main
+a := []
 
 # In order to handle manifest with one or many resources, we turns the input into an array, if it's not an array already.
 as_array(x) = [x] {not is_array(x)} else = x {true}
+
+
+authorize = "allow" {
+    input.user == "superuser"           # allow 'superuser' to perform any operation.
+} else = "deny" {
+    input.path[0] == "admin"            # disallow 'admin' operations...
+    input.source_network == "external"  # from external networks.
+}
+
+
+check_function_call_for_else(x) = x {
+    x % 2 == 0
+}else = abs(x) {
+    true
+}
+
+check_infix_op_for_else(x) = x {
+    x % 2 == 0
+} else = x *2 - 1 {
+    true
+}
+
+
+check_array_comprehension_for_else(x) = x {
+    x % 2 == 0
+} else = [y | some y; a[y] == x] {
+    true
+}
+
+check_set_comprehension_for_else(x) = x {
+    x % 2 == 0
+} else = {y | some y; a[y]} {
+    true
+}
+
+check_object_comprehension_for_else(x) = x {
+    x % 2 == 0
+} else = {y : "true" | some y;  a[y] } {
+    true
+}

--- a/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/else_keyword_2.rego
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/else_keyword_2.rego
@@ -1,8 +1,0 @@
-package test
-
-authorize = "allow" {
-    input.user == "superuser"           # allow 'superuser' to perform any operation.
-} else = "deny" {
-    input.path[0] == "admin"            # disallow 'admin' operations...
-    input.source_network == "external"  # from external networks.
-} # ... more rules

--- a/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/imports_between_rules.rego
+++ b/src/test/resources/org/openpolicyagent/ideaplugin/lang/parser/fixtures/imports_between_rules.rego
@@ -7,3 +7,12 @@ default allow = false
 allow {
     true
 }
+
+import data.domain
+import data.otherdomain as od
+
+rule_1 {
+    1 == 1
+}
+
+import data.something


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting your PR, some kind reminder

* If this is your first PR, please read our contributor guidelines: https://github.com/vgramer/opa-idea-plugin/blob/master/CONTRIBUTING.md

* Code should be accompanied by tests whenever it's possible.

* New feature must be documented

For more information about the project architecture please take a look at https://github.com/vgramer/opa-idea-plugin/tree/master/docs/devel

-->

# Description
Fix grammar to:
* allow imports between rules. Consequently, remove the useless grammar rule `policy`.
* allow `expr2` instead of `term` grammar rule in else statement


 
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`

If you just want to link an issue but not automatically close it, use `Ref #<issue number>` instead of  `Fixes`
-->
Fixes #76  
Fixes #78 

# Special notes for your reviewer
 'else keyword' and 'else keyword 2' tests have been merged into 'else keyword' test
