### PR TITLE
add security and DCO notice

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,7 @@
 <!-- toc -->
 - [Introduction](#introduction)
 - [Contribution](#contribution)
+  - [Developer Certificate Of Origin](#developer-certificate-of-origin)
 - [Helpful resources](#helpful-resources)
 <!-- /toc -->
 *to update toc, please read [this page](../../hack/README.md).*
@@ -20,6 +21,23 @@ If you are contributing code, please consider the following:
 * all tests must passed
 * add link to IntelliJ SDK documentation in JavaDoc, if the SDK documentation does not exist, please write a section in project architecture.
 
+## Developer Certificate Of Origin
+
+The OPA project requires that contributors sign off on changes submitted to OPA repositories. As opa-idea-plugin is now part of the OPA repositories, opa-idea-plugin requires contributors sign off on changes as well. The [Developer Certificate of Origin (DCO)](https://developercertificate.org/) is a simple way to certify that you wrote or have the right to submit the code you are contributing to the project.
+
+The DCO is a standard requirement for Linux Foundation and CNCF projects.
+
+You sign-off by adding the following to your commit messages:
+
+    This is my commit message
+
+    Signed-off-by: Random J Developer <random@developer.example.org>
+
+Git has a `-s` command line option to do this automatically.
+
+    git commit -s -m 'This is my commit message'
+
+You can find the full text of the DCO here: https://developercertificate.org/
 
 # Helpful resources
 * [IntelliJ sdk documentation](https://www.jetbrains.org/intellij/sdk/docs/intro/welcome.html)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,1 @@
+See [https://github.com/open-policy-agent/opa/blob/master/SECURITY.md](https://github.com/open-policy-agent/opa/blob/master/SECURITY.md)

--- a/docs/devel/setup_development_env.md
+++ b/docs/devel/setup_development_env.md
@@ -2,11 +2,12 @@
 <!-- toc -->
 - [Requirements](#requirements)
 - [Setup](#setup)
-- [Run a Sandbox ide to test plugin](#run-a-sandbox-ide-to-test-plugin)
+- [Main Gradle tasks](#main-gradle-tasks)
 - [Configuring the sandbox IDE](#configuring-the-sandbox-ide)
 - [Configuring the platform](#configuring-the-platform)
 - [Build the plugin archive](#build-the-plugin-archive)
 - [Other important tasks](#other-important-tasks)
+- [Configure IDE to automatically add license header](#configure-ide-to-automatically-add-license-header)
 <!-- /toc -->
 
 *to update toc, please read [this page](../../hack/README.md).*
@@ -93,22 +94,22 @@ the parser will be automatically generated.
 The code is generated in the [gen folder](../../src/main/gen). If you want to reset the generated, just delete the
 content of the gen folder and launch tasks `:generateRegoLexer` and `:generateRegoParser`.
 
- # Configure IDE to automatically add license header
- If it's not already done, please install the [copyright plugin](https://plugins.jetbrains.com/plugin/13114-copyright/).
- This plugin will automatically add the license header when you create a file.
- 
- To configure it , open the `Settings / Preferences dialog` and select `Editor | Copyright`. Create a new profile with 
- this license header:
- 
- ```
- Use of this source code is governed by the MIT license that can be
- found in the LICENSE file.
- ```
- 
- To check if project file contains the license header, run the script `hack/check-license.sh`
- 
- ```
- $ hack/check-license.sh
-   Checking files contains license header...
-   Check OK
- ```
+# Configure IDE to automatically add license header
+If it's not already done, please install the [copyright plugin](https://plugins.jetbrains.com/plugin/13114-copyright/).
+This plugin will automatically add the license header when you create a file.
+
+To configure it , open the `Settings / Preferences dialog` and select `Editor | Copyright`. Create a new profile with 
+this license header:
+
+```
+Use of this source code is governed by the MIT license that can be
+found in the LICENSE file.
+```
+
+To check if project file contains the license header, run the script `hack/check-license.sh`
+
+```
+$ hack/check-license.sh
+  Checking files contains license header...
+  Check OK
+```


### PR DESCRIPTION
this is required for migrating to open-policy-agent organization. see open-policy-agent/opa#3051
